### PR TITLE
Changed ACTIVATION_LABEL_ID to ACTIVATION_LABEL

### DIFF
--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -37,21 +37,20 @@ In order for you to start using Bluebot, you will need to install it on your rep
 
 ## 4. Configuring Bluebot
 
-At this time, Bluebot does not yet have a guided configuration process. You will need to go into the `./src/constants.ts` file and set the `LABEL_ID` and `PROJECT_URL` constants.
+At this time, Bluebot does not yet have a guided configuration process. You will need to go into the `./src/constants.ts` file and set the `ACTIVATION_LABEL` and `PROJECT_URL` constants.
 
 ```typescript
-export const ACTIVATION_LABEL_ID = 7750572746;
+export const ACTIVATION_LABEL = 'charlie-activation';
 export const PROJECT_URL = 'https://github.com/orgs/Carleton-Blueprint/projects/14/views/1?sliceBy%5BcolumnId%5D=Milestone';
 ```
 
-`ACTIVATION_LABEL_ID`
+`ACTIVATION_LABEL`
 
-:   - In order to not respond to every single issue event, `ACTIVATION_LABEL_ID` is used to filter events and trigger Bluebot's workflow only on issues with this label.
-    - Find the label ID of your target label by using the [GitHub Debug Panel](#verifying).
-    - You can configure your "New Issue" template to **automatically add this label to new issues**. See [^^this example^^](https://github.com/Carleton-Blueprint/.github/blob/main/.github/ISSUE_TEMPLATE/3-new-project.yml?plain=1). *Make sure to create a repository-level override instead of putting this in the global `.github` repository.*
-    
+- To ensure Bluebot only responds to relevant issue events, `ACTIVATION_LABEL` is used to filter issues by their label name and trigger Bluebot's workflow. 
+    - Set this constant to the **exact name** of the label you want to use for activation.
+    - You can configure your "New Issue" template to **automatically add this label to new issues**. See [this example](https://github.com/Carleton-Blueprint/.github/blob/main/.github/ISSUE_TEMPLATE/3-new-project.yml?plain=1). *Make sure to create a repository-level override instead of putting this in the global `.github` repository.*
 
 `PROJECT_URL`
 
-:   - This is the URL of the project board that Bluebot will be interacting with. ^^Bluebot **does not** interact with this project board directly^^ (GitHub's current API does not yet support project interactions), but it uses this URL to generate links to the project board in the comments it makes on issues.
+- This is the URL of the project board that Bluebot will be interacting with. Bluebot **does not** interact with this project board directly (GitHub's current API does not yet support project interactions), but it uses this URL to generate links to the project board in the comments it makes on issues.
     - You can configure a [GitHub automation](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically) to automatically add your new issues to this project.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
-export const ACTIVATION_LABEL_ID = 7750572746;
+// export const ACTIVATION_LABEL_ID = 7711881973;
+export const ACTIVATION_LABEL = 'charlie-activation';
 export const MAX_STAGE = 5;
 
 // Note: expect auto-add to have been set up already: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
-import { ACTIVATION_LABEL_ID, METADATA_REGEX, PROJECT_URL } from '../constants';
+// import { ACTIVATION_LABEL_ID, METADATA_REGEX, PROJECT_URL } from '../constants';
+import { ACTIVATION_LABEL, METADATA_REGEX, PROJECT_URL } from '../constants';
 import { Logger, IssuesContext, IssueMetadata, Issue } from './types';
 
 // Given a metadata object, generate a markdown string to be appended to the body of an issue.
@@ -20,7 +21,10 @@ export const getProjectUrl = (milestoneTitle: string) => {
 // Check if the issue has the correct label. Requires `ACTIVATION_LABEL_ID` to be set in constants.ts.
 export const isLabelCorrect = (context: IssuesContext, logger: Logger) => {
   const receivedIssue = context.payload.issue;
-  const isLabelCorrect = receivedIssue.labels?.some(label => label.id === ACTIVATION_LABEL_ID) ?? false;
+  
+  // const isLabelCorrect = receivedIssue.labels?.some(label => label.name === ACTIVATION_LABEL_ID) ?? false;
+  //use ACTIVATION_LABEL to match label.name
+  const isLabelCorrect = receivedIssue.labels?.some(label => label.name === ACTIVATION_LABEL) ?? false;   
 
   logger.info(
     `Checking issue label of '${receivedIssue.title}'... ${


### PR DESCRIPTION
# Description of Changes
Changed `ACTIVATION_LABEL_ID` to `ACTIVATION_LABEL` instead and updated the installation page


![image](https://github.com/user-attachments/assets/0b8d6a07-ef58-468c-9f67-760488dd34e0)

Also it seems every single label name has to be unique in the GitHub issue, as it prevented me from creating a duplicate issue label. Therefore, duplicate name seems not to be a concern.

Thank you.

## Related Issues

- Closes [[feat] Change ACTIVATION_LABEL_ID to ACTIVATION_LABEL #127](https://github.com/Carleton-Blueprint/carleton-blueprint.github.io/issues/127)

## Checklist

- [x] MR title is meaningful and accurate
- [x] This MR has an associated GitHub Issues ticket
- [x] GitHub Issues ticket fix version for this issue is correct
- [ ] ~[Changelog entry](https://keepachangelog.com/en/1.0.0/) has been made~
- [x] I promise that my commit message for this MR will be clear, meaningful,
      and useful to others. I will ensure this by editing the final commit message
      in GitHub prior to merging

If a checklist item is completed for this MR, place an `x` inside of the square
brackets for that item. If a checklist item is not applicable for this MR, please
note that by wrapping that line with `~` characters, ~like this~.

> Make sure you squash your commits before merging!
